### PR TITLE
[#5] Feature: 아카이브/찜 페이지에 힌트 보기 기능 추가

### DIFF
--- a/src/app/archive/[id]/page.tsx
+++ b/src/app/archive/[id]/page.tsx
@@ -39,6 +39,7 @@ import {
   type ApiSessionDetail,
 } from "@/lib/api";
 import { AIAnalysisSection } from "@/components/feedback/AIAnalysisSection";
+import { HintSection } from "@/components/feedback/HintSection";
 
 // Extended Question type with answerId
 interface QuestionWithAnswerId extends Question {
@@ -379,6 +380,11 @@ export default function ArchiveDetailPage() {
                         <p className="text-foreground leading-relaxed">
                           {question.content}
                         </p>
+
+                        {/* 힌트 섹션 */}
+                        {question.hint && (
+                          <HintSection hint={question.hint} className="mt-4" />
+                        )}
                       </div>
                       <div className="flex items-center gap-2">
                         <button

--- a/src/app/favorites/page.tsx
+++ b/src/app/favorites/page.tsx
@@ -48,6 +48,7 @@ import { cache, createCacheKey } from "@/lib/cache";
 import { LoginPromptModal } from "@/components/LoginPromptModal";
 import { ShareToTeamSpaceDialog } from "@/components/ShareToTeamSpaceDialog";
 import { useRouter } from "next/navigation";
+import { HintSection } from "@/components/feedback/HintSection";
 
 export default function FavoritesPage() {
   const router = useRouter();
@@ -739,6 +740,11 @@ export default function FavoritesPage() {
                             {favorite.content}
                           </p>
                         </div>
+
+                        {/* 힌트 섹션 */}
+                        {favorite.hint && (
+                          <HintSection hint={favorite.hint} className="mb-3" />
+                        )}
 
                         <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap">
                           <Badge variant="outline" className="text-xs">

--- a/src/app/interview/page.tsx
+++ b/src/app/interview/page.tsx
@@ -9,7 +9,6 @@ import {
   ChevronRight,
   CloudCheck,
   Heart,
-  Lightbulb,
   Loader2,
   Send,
 } from "lucide-react";
@@ -33,6 +32,7 @@ import {
   type ApiSessionDetail,
 } from "@/lib/api";
 import { formatSeconds } from "@/hooks/useTimer";
+import { HintSection } from "@/components/feedback/HintSection";
 
 // 로컬 스토리지 키 생성
 const getStorageKey = (sessionId: string) => `interview_progress_${sessionId}`;
@@ -624,43 +624,11 @@ function InterviewContent() {
                 </Card>
 
                 {/* Hint Section */}
-                <div className="space-y-3">
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => setShowHint(!showHint)}
-                    className="gap-2"
-                  >
-                    <Lightbulb
-                      className={`w-4 h-4 ${showHint ? "text-gold" : ""}`}
-                    />
-                    {showHint ? "힌트 숨기기" : "힌트 보기"}
-                  </Button>
-
-                  <AnimatePresence>
-                    {showHint && (
-                      <motion.div
-                        initial={{ opacity: 0, height: 0 }}
-                        animate={{ opacity: 1, height: "auto" }}
-                        exit={{ opacity: 0, height: 0 }}
-                      >
-                        <Card className="p-4 bg-gold/5 border-gold/20">
-                          <div className="flex items-start gap-3">
-                            <Lightbulb className="w-5 h-5 text-gold flex-shrink-0 mt-0.5" />
-                            <div>
-                              <p className="font-medium text-sm text-gold mb-1">
-                                힌트
-                              </p>
-                              <p className="text-muted-foreground">
-                                {currentQuestion.hint}
-                              </p>
-                            </div>
-                          </div>
-                        </Card>
-                      </motion.div>
-                    )}
-                  </AnimatePresence>
-                </div>
+                <HintSection
+                  hint={currentQuestion.hint}
+                  isOpen={showHint}
+                  onToggle={() => setShowHint(!showHint)}
+                />
 
                 {/* Navigation */}
                 <div className="flex items-center justify-between pt-4">

--- a/src/components/feedback/HintSection.tsx
+++ b/src/components/feedback/HintSection.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useState, useCallback, memo } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Lightbulb } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface HintSectionProps {
+  hint: string;
+  /** 초기 열림 상태 (uncontrolled 모드) */
+  defaultOpen?: boolean;
+  /** 외부에서 열림 상태 제어 (controlled 모드) */
+  isOpen?: boolean;
+  /** 열림 상태 변경 핸들러 (controlled 모드) */
+  onToggle?: () => void;
+  className?: string;
+}
+
+/**
+ * HintSection - 힌트를 토글 버튼으로 표시하는 컴포넌트
+ * AI 분석 섹션과 일관된 스타일을 유지하면서 독립적으로 사용 가능
+ *
+ * @example Uncontrolled 모드 (아카이브/찜 페이지)
+ * <HintSection hint={question.hint} />
+ *
+ * @example Controlled 모드 (면접 페이지)
+ * <HintSection hint={question.hint} isOpen={showHint} onToggle={() => setShowHint(!showHint)} />
+ */
+export const HintSection = memo(function HintSection({
+  hint,
+  defaultOpen = false,
+  isOpen: controlledIsOpen,
+  onToggle,
+  className,
+}: HintSectionProps) {
+  // Controlled vs Uncontrolled 모드 결정
+  const isControlled = controlledIsOpen !== undefined;
+  const [internalIsOpen, setInternalIsOpen] = useState(defaultOpen);
+
+  // 실제 열림 상태
+  const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
+
+  const handleToggle = useCallback(() => {
+    if (isControlled && onToggle) {
+      onToggle();
+    } else {
+      setInternalIsOpen((prev) => !prev);
+    }
+  }, [isControlled, onToggle]);
+
+  // 힌트가 없으면 렌더링하지 않음
+  if (!hint || hint.trim() === "") {
+    return null;
+  }
+
+  return (
+    <div className={cn("", className)}>
+      {/* 힌트 토글 버튼 */}
+      <button
+        onClick={handleToggle}
+        className={cn(
+          "inline-flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-medium transition-all",
+          isOpen
+            ? "bg-gold text-white"
+            : "bg-muted hover:bg-muted/80 text-foreground",
+        )}
+        aria-expanded={isOpen}
+        aria-controls="hint-content"
+      >
+        <Lightbulb className="w-4 h-4" />
+        <span>{isOpen ? "힌트 숨기기" : "힌트 보기"}</span>
+      </button>
+
+      {/* 힌트 콘텐츠 */}
+      <AnimatePresence initial={false}>
+        {isOpen && (
+          <motion.div
+            id="hint-content"
+            initial={{ height: 0, opacity: 0 }}
+            animate={{ height: "auto", opacity: 1 }}
+            exit={{ height: 0, opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            className="overflow-hidden"
+          >
+            <div className="mt-3 rounded-lg border-l-4 border-gold bg-gold/5 p-4">
+              {/* 섹션 헤더 */}
+              <div className="flex items-center gap-2 mb-3 pb-2 border-b border-gold/20">
+                <Lightbulb className="w-4 h-4 text-gold" />
+                <h4 className="font-medium text-gold text-sm">힌트</h4>
+              </div>
+
+              {/* 힌트 텍스트 */}
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                {hint}
+              </p>
+            </div>
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+});
+
+export default HintSection;


### PR DESCRIPTION
## Summary

- 아카이브 상세 페이지와 찜 페이지에서 힌트를 확인할 수 있는 기능 추가
- 재사용 가능한 `HintSection` 컴포넌트 생성
- 면접 페이지 힌트 UI를 `HintSection`으로 통일하여 일관된 UX 제공

## Changes

### New Files
- `src/components/feedback/HintSection.tsx` - 힌트 토글 컴포넌트
  - Controlled/Uncontrolled 모드 지원
  - Framer Motion 애니메이션
  - Gold 테마 스타일

### Modified Files
- `src/app/archive/[id]/page.tsx` - 질문 헤더에 HintSection 추가
- `src/app/favorites/page.tsx` - 질문 카드에 HintSection 추가
- `src/app/interview/page.tsx` - 기존 힌트 UI를 HintSection으로 대체

## Test Plan

- [ ] 아카이브 상세 페이지에서 힌트 버튼 클릭 시 힌트 표시/숨김
- [ ] 찜 페이지에서 힌트 버튼 클릭 시 힌트 표시/숨김
- [ ] 면접 페이지에서 힌트 토글 정상 작동
- [ ] 질문 변경 시 힌트가 자동으로 닫힘 (면접 페이지)
- [ ] 힌트가 없는 질문에서는 버튼이 표시되지 않음
- [ ] 모바일 반응형 확인

## Related Issue

Closes #5

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)