### PR TITLE
[#7] Feature: 면접 범주(Interview Type) 시스템 구현

### DIFF
--- a/src/app/api/interview-types/route.ts
+++ b/src/app/api/interview-types/route.ts
@@ -1,0 +1,53 @@
+import { NextResponse } from "next/server";
+import { supabaseAdmin } from "@/lib/supabase";
+
+// GET /api/interview-types - 면접 범주 목록 조회
+export async function GET() {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const { data: interviewTypes, error } = await (supabaseAdmin as any)
+      .from("interview_types")
+      .select("*")
+      .order("sort_order", { ascending: true });
+
+    if (error) {
+      console.error("면접 범주 조회 실패:", error);
+      return NextResponse.json(
+        { error: "면접 범주를 불러올 수 없습니다" },
+        { status: 500 },
+      );
+    }
+
+    // snake_case → camelCase 변환
+    const formattedTypes = interviewTypes.map(
+      (type: {
+        id: string;
+        code: string;
+        name: string;
+        display_name: string;
+        description: string | null;
+        icon: string | null;
+        color: string | null;
+        sort_order: number;
+        created_at: string;
+      }) => ({
+        id: type.id,
+        code: type.code,
+        name: type.name,
+        displayName: type.display_name,
+        description: type.description,
+        icon: type.icon,
+        color: type.color,
+        sortOrder: type.sort_order,
+      }),
+    );
+
+    return NextResponse.json({ interviewTypes: formattedTypes });
+  } catch (error) {
+    console.error("면접 범주 조회 실패:", error);
+    return NextResponse.json(
+      { error: "면접 범주를 불러올 수 없습니다" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/questions/generate/route.ts
+++ b/src/app/api/questions/generate/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { generateQuestions, type SupportedMediaType } from "@/lib/claude";
 import { validateInterviewInput } from "@/lib/validation";
+import type { InterviewTypeCode } from "@/types/interview";
 
 // POST /api/questions/generate - Claude로 질문 생성 (세션 저장 없이)
 export async function POST(request: NextRequest) {
@@ -11,11 +12,13 @@ export async function POST(request: NextRequest) {
       exclude_questions,
       count,
       reference_urls,
+      interview_type,
     }: {
       query: string;
       exclude_questions?: string[];
       count?: number;
       reference_urls?: Array<{ url: string; type: SupportedMediaType }>;
+      interview_type?: InterviewTypeCode;
     } = body;
 
     // 입력 검증 - 빈 쿼리
@@ -52,14 +55,16 @@ export async function POST(request: NextRequest) {
       count: questionCount,
       referenceUrlsCount: reference_urls?.length || 0,
       referenceUrls: reference_urls,
+      interviewType: interview_type,
     });
 
-    // Claude로 질문 생성 (레퍼런스 URL 포함)
+    // Claude로 질문 생성 (레퍼런스 URL 및 면접 범주 포함)
     const result = await generateQuestions(
       query,
       excludeQuestions,
       questionCount,
       reference_urls,
+      interview_type,
     );
 
     console.log("생성된 질문:", {

--- a/src/components/InterviewTypeSelector.tsx
+++ b/src/components/InterviewTypeSelector.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { motion } from "framer-motion";
+import { Brain, FolderKanban, Network, Check, Sparkles } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { ApiInterviewType } from "@/lib/api";
+
+// 아이콘 매핑
+const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
+  Brain,
+  FolderKanban,
+  Network,
+};
+
+// 색상 매핑 (Tailwind 클래스)
+const COLOR_MAP: Record<
+  string,
+  {
+    bg: string;
+    bgLight: string;
+    border: string;
+    text: string;
+    selectedBg: string;
+    hoverBorder: string;
+  }
+> = {
+  blue: {
+    bg: "bg-blue-100",
+    bgLight: "bg-blue-50",
+    border: "border-blue-300",
+    text: "text-blue-600",
+    selectedBg: "bg-blue-50",
+    hoverBorder: "hover:border-blue-200",
+  },
+  green: {
+    bg: "bg-emerald-100",
+    bgLight: "bg-emerald-50",
+    border: "border-emerald-300",
+    text: "text-emerald-600",
+    selectedBg: "bg-emerald-50",
+    hoverBorder: "hover:border-emerald-200",
+  },
+  purple: {
+    bg: "bg-purple-100",
+    bgLight: "bg-purple-50",
+    border: "border-purple-300",
+    text: "text-purple-600",
+    selectedBg: "bg-purple-50",
+    hoverBorder: "hover:border-purple-200",
+  },
+};
+
+interface InterviewTypeSelectorProps {
+  interviewTypes: ApiInterviewType[];
+  selectedTypeId: string | null;
+  onSelect: (typeId: string | null) => void;
+  disabled?: boolean;
+}
+
+export function InterviewTypeSelector({
+  interviewTypes,
+  selectedTypeId,
+  onSelect,
+  disabled = false,
+}: InterviewTypeSelectorProps) {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  if (!isMounted) {
+    return (
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="h-[160px] rounded-xl bg-muted/50 animate-pulse"
+          />
+        ))}
+      </div>
+    );
+  }
+
+  const handleSelect = (typeId: string) => {
+    if (disabled) return;
+    // 같은 타입 클릭 시 선택 해제
+    if (selectedTypeId === typeId) {
+      onSelect(null);
+    } else {
+      onSelect(typeId);
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+      {interviewTypes.map((type) => {
+        const isSelected = selectedTypeId === type.id;
+        const IconComponent = ICON_MAP[type.icon || "Brain"] || Brain;
+        const colors = COLOR_MAP[type.color || "blue"] || COLOR_MAP.blue;
+
+        return (
+          <motion.button
+            key={type.id}
+            type="button"
+            onClick={() => handleSelect(type.id)}
+            disabled={disabled}
+            className={cn(
+              "relative flex flex-col items-start text-left p-4 rounded-xl border-2 transition-all duration-200",
+              "focus:outline-none focus-visible:outline-none",
+              disabled && "opacity-50 cursor-not-allowed",
+              isSelected
+                ? `${colors.selectedBg} ${colors.border} shadow-md`
+                : `bg-card border-border/50 ${colors.hoverBorder} hover:shadow-sm`,
+            )}
+          >
+            {/* 선택 표시 */}
+            {isSelected && (
+              <motion.div
+                initial={{ scale: 0 }}
+                animate={{ scale: 1 }}
+                className={cn(
+                  "absolute top-3 right-3 w-6 h-6 rounded-full flex items-center justify-center",
+                  colors.bg,
+                  colors.text,
+                )}
+              >
+                <Check className="w-3.5 h-3.5" strokeWidth={3} />
+              </motion.div>
+            )}
+
+            {/* 아이콘 */}
+            <div
+              className={cn(
+                "w-10 h-10 rounded-xl flex items-center justify-center mb-3",
+                colors.bg,
+              )}
+            >
+              <IconComponent className={cn("w-5 h-5", colors.text)} />
+            </div>
+
+            {/* 제목 */}
+            <h3
+              className={cn(
+                "text-base font-semibold mb-1",
+                isSelected ? colors.text : "text-foreground",
+              )}
+            >
+              {type.displayName}
+            </h3>
+
+            {/* 설명 - 전체 표시 */}
+            <p className="text-sm text-muted-foreground leading-relaxed mb-3">
+              {type.description}
+            </p>
+
+            {/* 선택 시 혜택 안내 */}
+            <div
+              className={cn(
+                "flex items-center gap-1.5 text-xs font-medium mt-auto pt-2 border-t border-border/30 w-full",
+                isSelected ? colors.text : "text-muted-foreground",
+              )}
+            >
+              <Sparkles className="w-3.5 h-3.5" />
+              <span>이 분야 맞춤 질문 생성</span>
+            </div>
+          </motion.button>
+        );
+      })}
+    </div>
+  );
+}
+
+// 선택된 면접 범주를 배지로 표시하는 컴포넌트
+interface InterviewTypeBadgeProps {
+  type: ApiInterviewType;
+  size?: "sm" | "md";
+}
+
+export function InterviewTypeBadge({
+  type,
+  size = "sm",
+}: InterviewTypeBadgeProps) {
+  const IconComponent = ICON_MAP[type.icon || "Brain"] || Brain;
+  const colors = COLOR_MAP[type.color || "blue"] || COLOR_MAP.blue;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 rounded-full font-medium",
+        colors.bg,
+        colors.text,
+        size === "sm" ? "px-2 py-0.5 text-xs" : "px-3 py-1 text-sm",
+      )}
+    >
+      <IconComponent className={cn(size === "sm" ? "w-3 h-3" : "w-4 h-4")} />
+      {type.displayName}
+    </span>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -276,6 +276,27 @@ export async function setLastSelectedTeamSpaceApi(
   );
 }
 
+// ============ Interview Types API ============
+
+export interface ApiInterviewType {
+  id: string;
+  code: string;
+  name: string;
+  displayName: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  sortOrder: number;
+}
+
+interface InterviewTypesResponse {
+  interviewTypes: ApiInterviewType[];
+}
+
+export async function getInterviewTypesApi(): Promise<InterviewTypesResponse> {
+  return fetchApi<InterviewTypesResponse>("/api/interview-types");
+}
+
 // ============ Favorites API ============
 
 export interface ApiFavorite {
@@ -358,6 +379,8 @@ export interface ApiSession {
   total_time: number;
   is_completed: boolean;
   question_count: number;
+  interview_type_id?: string | null;
+  interview_type?: ApiInterviewType | null;
   created_at: string;
   user_id: string; // 소유자 ID 추가
   shared_by?: {
@@ -408,6 +431,7 @@ export async function getSessionsApi(
     teamSpaceId?: string | null;
     startDate?: string | null;
     endDate?: string | null;
+    interviewTypeId?: string | null;
   },
 ): Promise<SessionsResponse> {
   const params = new URLSearchParams({
@@ -422,6 +446,9 @@ export async function getSessionsApi(
   }
   if (options?.endDate) {
     params.append("end_date", options.endDate);
+  }
+  if (options?.interviewTypeId) {
+    params.append("interview_type_id", options.interviewTypeId);
   }
   return fetchApi<SessionsResponse>(`/api/sessions?${params.toString()}`);
 }
@@ -438,6 +465,7 @@ export async function createSessionApi(
     category: string;
     questionId?: string; // 기존 질문 ID (있으면 사용)
   }>,
+  interviewTypeId?: string | null,
 ): Promise<{ session: { id: string; created_at: string } }> {
   // questionId가 있는 경우 question_ids로 전달
   const questionIds = questions
@@ -454,6 +482,7 @@ export async function createSessionApi(
         hint: q.hint,
         category: q.category,
       })),
+      interview_type_id: interviewTypeId || undefined,
     }),
   });
 }
@@ -526,6 +555,7 @@ export async function generateQuestionsApi(
   query: string,
   excludeQuestions: string[] = [],
   count: number = 5,
+  interviewType?: string | null,
 ): Promise<GeneratedQuestion[]> {
   const data = await fetchApi<{ questions: GeneratedQuestion[] }>(
     "/api/questions/generate",
@@ -535,6 +565,7 @@ export async function generateQuestionsApi(
         query,
         exclude_questions: excludeQuestions,
         count,
+        interview_type: interviewType || undefined,
       }),
     },
   );

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -160,6 +160,7 @@ export interface Database {
           query: string;
           total_time: number;
           is_completed: boolean;
+          interview_type_id: string | null;
           created_at: string;
         };
         Insert: {
@@ -168,12 +169,14 @@ export interface Database {
           query: string;
           total_time?: number;
           is_completed?: boolean;
+          interview_type_id?: string | null;
           created_at?: string;
         };
         Update: {
           query?: string;
           total_time?: number;
           is_completed?: boolean;
+          interview_type_id?: string | null;
         };
       };
       session_questions: {
@@ -245,6 +248,39 @@ export interface Database {
           created_at?: string;
         };
         Update: Record<string, never>; // favorites는 업데이트하지 않음
+      };
+      interview_types: {
+        Row: {
+          id: string;
+          code: string;
+          name: string;
+          display_name: string;
+          description: string | null;
+          icon: string | null;
+          color: string | null;
+          sort_order: number;
+          created_at: string;
+        };
+        Insert: {
+          id?: string;
+          code: string;
+          name: string;
+          display_name: string;
+          description?: string | null;
+          icon?: string | null;
+          color?: string | null;
+          sort_order?: number;
+          created_at?: string;
+        };
+        Update: {
+          code?: string;
+          name?: string;
+          display_name?: string;
+          description?: string | null;
+          icon?: string | null;
+          color?: string | null;
+          sort_order?: number;
+        };
       };
       answer_feedback: {
         Row: {
@@ -388,6 +424,11 @@ export type AnswerFeedbackInsert =
   Database["public"]["Tables"]["answer_feedback"]["Insert"];
 export type AnswerFeedbackUpdate =
   Database["public"]["Tables"]["answer_feedback"]["Update"];
+
+export type InterviewType =
+  Database["public"]["Tables"]["interview_types"]["Row"];
+export type InterviewTypeInsert =
+  Database["public"]["Tables"]["interview_types"]["Insert"];
 
 // JWT Payload Types
 export interface AccessTokenPayload {

--- a/src/types/interview.ts
+++ b/src/types/interview.ts
@@ -3,6 +3,20 @@
  * Based on PRD.md data structure specification
  */
 
+// Interview Type (면접 범주) types
+export type InterviewTypeCode = "CS" | "PROJECT" | "SYSTEM_DESIGN";
+
+export interface InterviewTypeInfo {
+  id: string;
+  code: string; // 'CS' | 'PROJECT' | 'SYSTEM_DESIGN' but stored as string from API
+  name: string;
+  displayName: string;
+  description: string | null;
+  icon: string | null;
+  color: string | null;
+  sortOrder: number;
+}
+
 export interface Question {
   id: string;
   content: string;
@@ -23,6 +37,7 @@ export interface InterviewSession {
   totalTime: number;
   isCompleted: boolean;
   user_id?: string; // 소유자 ID (삭제 권한 확인용)
+  interviewType?: InterviewTypeInfo | null; // 면접 범주
   sharedBy?: {
     id: string;
     username: string;


### PR DESCRIPTION
## Summary

- 면접 범주 시스템 구현 (CS 기초, 프로젝트 기반, 시스템 설계)
- 범주별 특화 AI 프롬프트로 맞춤 질문 생성
- 홈페이지에 범주 선택 카드 UI 추가
- 아카이브 페이지에 범주별 필터링 기능

## Changes

### Database (Supabase)
- `interview_types` 테이블 생성 및 seed 데이터
- `interview_sessions`에 `interview_type_id` FK 추가
- RLS 정책 설정 (공개 읽기)

### API
- `GET /api/interview-types` - 범주 목록 조회
- `POST /api/sessions` - interview_type_id 저장
- `GET /api/sessions` - interview_type_id 필터링

### AI 질문 생성
- 범주별 특화 프롬프트 적용
- CS 기초: 이론적 개념 질문
- 프로젝트 기반: STAR 기법 행동 질문
- 시스템 설계: 아키텍처 설계 질문

### UI
- `InterviewTypeSelector` 컴포넌트 (카드형 선택 UI)
- 홈페이지에 범주 선택 섹션 추가
- 아카이브 페이지에 범주 필터 버튼

## Test Plan

- [ ] 홈페이지에서 면접 범주 선택 가능
- [ ] 범주 선택 후 검색 시 해당 분야 특화 질문 생성
- [ ] 아카이브에서 범주별 필터링 동작
- [ ] 기존 세션 (null 범주) 정상 표시
- [ ] 모바일 반응형 UI 확인

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)