### PR TITLE
[#13] Chore: Google Search Console 및 네이버 서치 어드바이저 SEO 등록 설정

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,16 +10,41 @@ export const metadata: Metadata = {
     "기술면접",
     "개발자",
     "면접 준비",
-    "React",
+    "AI 면접",
+    "모의면접",
     "프론트엔드",
     "백엔드",
-    "AI",
+    "React",
   ],
   authors: [{ name: "모카번" }],
+  verification: {
+    google: process.env.NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION,
+    other: {
+      ...(process.env.NEXT_PUBLIC_NAVER_SITE_VERIFICATION && {
+        "naver-site-verification":
+          process.env.NEXT_PUBLIC_NAVER_SITE_VERIFICATION,
+      }),
+    },
+  },
   openGraph: {
     title: "모카번 - AI 기술면접 준비",
-    description: "개발자 기술면접, AI와 함께 준비하세요",
+    description:
+      "개발자 기술면접, AI와 함께 준비하세요. 맞춤형 질문 생성과 실전 모의면접을 경험해보세요.",
     type: "website",
+    locale: "ko_KR",
+    url: "https://mochabun.com",
+    siteName: "모카번",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+    },
+  },
+  alternates: {
+    canonical: "https://mochabun.com",
   },
 };
 

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,17 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://mochabun.com";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/auth/", "/complete/"],
+      },
+    ],
+    sitemap: `${BASE_URL}/sitemap.xml`,
+    host: BASE_URL,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,53 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://mochabun.com";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  // Static pages
+  const staticPages: MetadataRoute.Sitemap = [
+    {
+      url: BASE_URL,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 1,
+    },
+    {
+      url: `${BASE_URL}/auth`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.3,
+    },
+    {
+      url: `${BASE_URL}/search`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/interview`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.9,
+    },
+    {
+      url: `${BASE_URL}/archive`,
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.8,
+    },
+    {
+      url: `${BASE_URL}/favorites`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
+    {
+      url: `${BASE_URL}/team-spaces/new`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+
+  return staticPages;
+}


### PR DESCRIPTION
## Summary

- Next.js App Router의 MetadataRoute를 활용한 `/sitemap.xml`, `/robots.txt` 자동 생성
- Google/Naver 검색엔진 소유권 인증을 위한 verification 메타태그 환경변수 기반 주입
- OpenGraph 메타데이터 강화 (locale, url, siteName, canonical)

## Changes

| 파일 | 변경 |
|---|---|
| `src/app/sitemap.ts` | 신규 - 정적 페이지 7개 포함 sitemap 생성 |
| `src/app/robots.ts` | 신규 - 크롤러 규칙 (`/api/`, `/auth/`, `/complete/` 차단) |
| `src/app/layout.tsx` | 수정 - verification, OpenGraph, canonical, robots 메타데이터 |

## 환경변수 (배포 시 추가 필요)

```
NEXT_PUBLIC_GOOGLE_SITE_VERIFICATION=<Google Search Console 인증 코드>
NEXT_PUBLIC_NAVER_SITE_VERIFICATION=<네이버 서치 어드바이저 인증 코드>
```

## Test plan

- [ ] `/sitemap.xml` 접속 시 유효한 XML 응답 확인
- [ ] `/robots.txt` 접속 시 크롤러 규칙 확인
- [ ] 페이지 소스에서 OpenGraph, canonical, robots 메타태그 확인
- [ ] 환경변수 미설정 시 빌드 에러 없이 정상 동작 확인
- [ ] `npm run build` 성공

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)