### PR TITLE
[#43] Bug: 홈 화면 면접 범주 선택 카드 느린 렌더링 원인 분석 및 개선

### DIFF
--- a/docs/plans/043-refactor-interview-type-to-static-data.md
+++ b/docs/plans/043-refactor-interview-type-to-static-data.md
@@ -1,0 +1,323 @@
+# Plan: 면접 범주 선택 카드 정적 데이터 리팩토링
+
+**Issue**: [#43](https://github.com/kwakseongjae/dev-interview/issues/43)
+**Branch**: `fix/43-slow-interview-type-card-rendering`
+**Date**: 2026-03-04
+
+---
+
+## 1. Overview
+
+### 문제 정의
+
+홈 화면 "면접 범주 선택 (선택사항)" 카드가 페이지 로드 후 늦게 렌더링되는 원인은 `page.tsx`(Client Component)에서 `useEffect`로 `/api/interview-types` API를 호출하기 때문임.
+
+렌더링 지연 경로:
+
+```
+서버 HTML 전송 → JS hydration → useEffect 실행 → /api/interview-types 요청
+  → Supabase 쿼리 → 응답 → setState → 리렌더링 → 카드 표시
+```
+
+### 목표
+
+- 면접 범주 4종(CS, PROJECT, SYSTEM_DESIGN, CASE_STUDY)은 **완전히 정적인 데이터**로 정적 상수로 관리
+- API 호출 제거 → 홈 페이지 최초 렌더링 시 즉시 카드 표시
+- 연계된 `search/page.tsx` 및 세션 생성 플로우 호환성 유지
+
+### 범위
+
+- 홈 화면 카드 렌더링 최적화 (API 호출 제거)
+- `interview_type_id` (UUID) 의존성을 `code` 기반으로 전환
+- 세션 생성 API가 `code`를 받아 내부에서 UUID 조회하도록 변경
+
+---
+
+## 2. Requirements
+
+### FR (기능 요구사항)
+
+- **FR-1**: 홈 화면 면접 범주 카드가 API 호출 없이 즉시 렌더링됨
+- **FR-2**: `src/data/interview-types.ts`에 4종 면접 범주 정적 데이터 정의
+- **FR-3**: 기존 InterviewTypeSelector UI 동작 유지 (선택, 해제, 반응형)
+- **FR-4**: 면접 시작 시 세션에 `interview_type_id`(UUID) 정상 저장
+- **FR-5**: 아카이브 페이지 면접 범주 필터 동작 유지
+
+### TR (기술 요구사항)
+
+- **TR-1**: `InterviewTypeCode` 타입 (`src/types/interview.ts`)을 정적 데이터의 기준으로 사용
+- **TR-2**: `InterviewTypeSelector` props를 `ApiInterviewType[]` → 정적 타입 배열로 변경
+- **TR-3**: `page.tsx`의 `selectedInterviewTypeId`(UUID 기반) → `selectedInterviewTypeCode`(code 기반)로 전환
+- **TR-4**: 세션 생성 API(`/api/sessions POST`)가 `interview_type_code` 파라미터를 받아 UUID를 내부 조회
+- **TR-5**: 빌드/타입체크/린트 전부 통과
+
+---
+
+## 3. Architecture & Design
+
+### 데이터 구조
+
+```typescript
+// src/data/interview-types.ts (NEW)
+export interface StaticInterviewType {
+  code: InterviewTypeCode;
+  displayName: string;
+  description: string;
+  icon: string;   // ICON_MAP 키 ('Brain', 'FolderKanban', 'Network', 'BookOpen')
+  color: string;  // COLOR_MAP 키 ('blue', 'green', 'purple', 'amber')
+  sortOrder: number;
+}
+
+export const INTERVIEW_TYPES: StaticInterviewType[] = [
+  { code: "CS",            displayName: "CS 기초",        icon: "Brain",         color: "blue",   sortOrder: 1, ... },
+  { code: "PROJECT",       displayName: "프로젝트 기반",  icon: "FolderKanban",  color: "green",  sortOrder: 2, ... },
+  { code: "SYSTEM_DESIGN", displayName: "시스템 설계",    icon: "Network",       color: "purple", sortOrder: 3, ... },
+  { code: "CASE_STUDY",    displayName: "케이스 스터디",  icon: "BookOpen",      color: "amber",  sortOrder: 4, ... },
+];
+```
+
+### 변경 후 홈 → 검색 → 세션 생성 플로우
+
+```
+[홈 page.tsx]
+  INTERVIEW_TYPES (정적) → InterviewTypeSelector
+  선택 → selectedInterviewTypeCode: "CS" | "PROJECT" | ...
+  제출 → URL params: ?interview_type=CS (interview_type_id 제거)
+
+[search/page.tsx]
+  interviewTypeCode = searchParams.get("interview_type")
+  typeInfo = INTERVIEW_TYPES.find(t => t.code === interviewTypeCode)  ← 정적 lookup
+  세션 생성 시 → createSessionApi(..., interviewTypeCode)  (UUID 대신 code 전달)
+
+[/api/sessions POST]
+  interview_type_code 수신 → interview_types 테이블에서 UUID 조회
+  interview_type_id = DB lookup 결과 → 세션에 저장
+```
+
+---
+
+## 4. Implementation Plan
+
+### Step 1: 정적 데이터 파일 생성
+
+**파일**: `src/data/interview-types.ts` (NEW)
+
+- `StaticInterviewType` 인터페이스 정의 (ApiInterviewType에서 `id` 제거)
+- `INTERVIEW_TYPES` 상수 배열 정의 (4종)
+- `getInterviewTypeByCode()` 헬퍼 함수 추가
+
+### Step 2: InterviewTypeSelector props 타입 업데이트
+
+**파일**: `src/components/InterviewTypeSelector.tsx`
+
+- `interviewTypes: ApiInterviewType[]` → `interviewTypes: StaticInterviewType[]`
+- `selectedTypeId` → `selectedTypeCode` (string → InterviewTypeCode | null)
+- ICON_MAP/COLOR_MAP은 그대로 유지 (이미 정적 상수)
+- `InterviewTypeBadge`도 같이 타입 업데이트
+
+### Step 3: 홈 page.tsx 리팩토링
+
+**파일**: `src/app/page.tsx`
+
+제거:
+
+- `interviewTypes` 상태 (`useState<ApiInterviewType[]>([])`)
+- `isLoadingInterviewTypes` 상태
+- `loadInterviewTypes` useEffect
+- `getInterviewTypesApi` import
+- 스켈레톤 로딩 UI 분기
+
+추가:
+
+- `INTERVIEW_TYPES` import from `@/data/interview-types`
+- `selectedInterviewTypeCode` 상태 (`useState<InterviewTypeCode | null>(null)`)
+
+수정:
+
+- `selectedInterviewTypeId` → `selectedInterviewTypeCode`
+- 제출 핸들러: `interview_type_id` URL param 제거, `interview_type` (code)만 유지
+- InterviewTypeSelector props 업데이트
+
+### Step 4: search/page.tsx 업데이트
+
+**파일**: `src/app/search/page.tsx`
+
+- `interviewTypeId` URL param 제거
+- 면접 범주 표시 정보: `INTERVIEW_TYPES.find(t => t.code === interviewTypeCode)` 로 lookup
+- `createSessionApi()` 호출 시 `interviewTypeId` → `interviewTypeCode` 전달
+- 하드코딩된 displayName 매핑 제거 (정적 데이터에서 가져옴)
+
+### Step 5: createSessionApi 및 세션 생성 API 업데이트
+
+**파일**: `src/lib/api.ts`
+
+- `createSessionApi` 파라미터: `interviewTypeId?: string` → `interviewTypeCode?: InterviewTypeCode`
+- URL param 변경: `interview_type_id` → `interview_type_code`
+
+**파일**: `src/app/api/sessions/route.ts`
+
+- POST handler: `interview_type_code` 수신
+- interview_types 테이블에서 UUID 조회: `.eq("code", interview_type_code)`
+- 조회된 UUID를 세션에 저장
+- GET handler: `interview_type_id` 필터 유지 (아카이브 필터용) 또는 `interview_type_code` 기반으로 전환
+
+### Step 6: 정리
+
+- `src/lib/api.ts`: `getInterviewTypesApi()` 및 `ApiInterviewType` 인터페이스 제거 (또는 deprecated 처리)
+- `src/app/api/interview-types/route.ts`: 사용 여부 확인 후 삭제 검토 (다른 곳에서 사용 안 하면 삭제)
+
+---
+
+## 5. Quality Gates
+
+- [ ] `npm run build` 성공
+- [ ] `npx tsc --noEmit` 타입 에러 없음
+- [ ] `npx eslint src/` lint 통과
+- [ ] 홈 화면 면접 범주 카드 즉시 렌더링 확인
+- [ ] 면접 범주 선택 후 검색 정상 동작
+- [ ] 세션 생성 후 DB에 `interview_type_id` 정상 저장 확인
+
+---
+
+## 6. Risks & Dependencies
+
+| 리스크                      | 영향도 | 완화 방법                                                      |
+| --------------------------- | ------ | -------------------------------------------------------------- |
+| 세션 생성 시 UUID 조회 실패 | 높음   | DB `interview_types` 테이블에 4종 데이터 존재 확인 (이미 존재) |
+| 아카이브 필터 동작 깨짐     | 중간   | archive/page.tsx의 interviewTypeId 사용 패턴 확인 후 처리      |
+| 타입 불일치                 | 낮음   | TypeScript 컴파일러가 즉시 감지                                |
+
+---
+
+## 7. Files to Change
+
+| 파일                                       | 변경 유형 | 주요 내용                                                 |
+| ------------------------------------------ | --------- | --------------------------------------------------------- |
+| `src/data/interview-types.ts`              | **신규**  | StaticInterviewType 타입 + INTERVIEW_TYPES 상수           |
+| `src/app/page.tsx`                         | 수정      | API 호출 제거, 정적 데이터 사용                           |
+| `src/components/InterviewTypeSelector.tsx` | 수정      | props 타입 업데이트                                       |
+| `src/app/search/page.tsx`                  | 수정      | interviewTypeId 제거, 정적 lookup                         |
+| `src/lib/api.ts`                           | 수정      | createSessionApi 파라미터 변경, getInterviewTypesApi 제거 |
+| `src/app/api/sessions/route.ts`            | 수정      | code → UUID 조회 로직 추가                                |
+| `src/app/api/interview-types/route.ts`     | 삭제 검토 | 미사용 시 삭제                                            |
+
+---
+
+## 8. References
+
+- Issue: [#43 홈 화면 면접 범주 선택 카드 느린 렌더링](https://github.com/kwakseongjae/dev-interview/issues/43)
+- 관련: `src/data/trend-topics.ts` (정적 데이터 파일 패턴 참조)
+- 관련: `src/types/interview.ts` (`InterviewTypeCode` 타입)
+
+---
+
+## Implementation Summary
+
+**Completion Date**: 2026-03-04
+**Implemented By**: Claude Sonnet 4.6
+
+### Changes Made
+
+| 파일                                                                                                                   | 변경 유형   | 주요 내용                                                                                                               |
+| ---------------------------------------------------------------------------------------------------------------------- | ----------- | ----------------------------------------------------------------------------------------------------------------------- |
+| [`src/data/interview-types.ts`](src/data/interview-types.ts)                                                           | **신규**    | `StaticInterviewType` 인터페이스, `INTERVIEW_TYPES` 상수(4종), `getInterviewTypeByCode()` 헬퍼                          |
+| [`src/components/InterviewTypeSelector.tsx`](src/components/InterviewTypeSelector.tsx)                                 | 전면 재작성 | 카드 그리드 → Popover 기반 UI로 전환. `InterviewTypePopoverSelector`, `SelectedInterviewTypePill`, `InterviewTypeBadge` |
+| [`src/app/page.tsx`](src/app/page.tsx)                                                                                 | 수정        | API 호출/로딩 상태/스켈레톤 제거. 위 카드 영역 제거. 하단 툴바 + 입력창 내부 Pill 방식으로 전환                         |
+| [`src/app/search/page.tsx`](src/app/search/page.tsx)                                                                   | 수정        | `interviewTypeId` URL 파라미터 제거. 하드코딩 displayName 제거. `getInterviewTypeByCode()`로 대체                       |
+| [`src/lib/api.ts`](src/lib/api.ts)                                                                                     | 수정        | `createSessionApi()` 파라미터: `interviewTypeId` → `interviewTypeCode`                                                  |
+| [`src/app/api/sessions/route.ts`](src/app/api/sessions/route.ts)                                                       | 수정        | `interview_type_code` 수신 후 DB에서 UUID 내부 조회                                                                     |
+| [`docs/plans/043-refactor-interview-type-to-static-data.md`](docs/plans/043-refactor-interview-type-to-static-data.md) | 신규        | 계획 문서                                                                                                               |
+
+### Key Implementation Details
+
+- **정적 데이터 전환**: 4종 면접 범주를 `INTERVIEW_TYPES` 배열로 정의. API 호출 없이 즉시 렌더링
+- **식별자 변경**: UUID(`id`) 기반 → `code`(CS/PROJECT/SYSTEM_DESIGN/CASE_STUDY) 기반으로 프론트엔드 전체 통일
+- **UUID 역방향 조회**: 백엔드 세션 생성 시 `interview_type_code`를 받아 DB에서 `interview_type_id`(UUID) 자동 조회
+- **UI 패턴 통일**: `TrendTopicSelector`와 동일한 Popover 패턴으로 면접 범주 선택 UI 재설계
+- **디테일 표시**: Popover 2×2 카드에 아이콘 + 이름 + 설명 전체 표시
+- **InterviewTypeBadge 호환성 유지**: 최소 인터페이스(`displayName`, `icon`, `color`)만 요구해 아카이브/검색 등 기존 코드 무변경
+
+### Deviations from Plan
+
+**Added (계획 외 추가)**:
+
+- `InterviewTypePopoverSelector`를 트렌드 토픽과 동일한 Popover 패턴으로 구현 (계획 문서에는 UI 방식 미확정)
+- `SelectedInterviewTypePill` 컴포넌트 추가 (입력창 내부 상단 표시)
+- 면접 범주 + 트렌드 토픽 Pill이 동시에 나란히 표시되는 레이아웃
+
+**Changed (변경)**:
+
+- 계획상 `getInterviewTypesApi` 제거로 명시했으나, `archive/page.tsx`가 여전히 사용하므로 유지
+
+**Skipped (미구현)**:
+
+- `/api/interview-types` 라우트 삭제 (archive 페이지 필터용으로 여전히 필요하여 유지)
+
+### Quality Validation
+
+- [x] Build: Success (`npm run build`)
+- [x] Type Check: Passed (`npx tsc --noEmit`)
+- [x] Lint: Passed (`npx eslint`)
+
+---
+
+## QA Checklist
+
+> 🤖 Generated by qa-generator agent
+> Date: 2026-03-04
+
+### 테스트 요약
+
+- **총 테스트 케이스**: 31개
+- **우선순위별**: High 13, Medium 12, Low 6
+- **예상 테스트 시간**: 60분
+
+### 기능 테스트
+
+| #     | 테스트 시나리오                 | 테스트 단계                               | 예상 결과                                                                    | 우선순위 |
+| ----- | ------------------------------- | ----------------------------------------- | ---------------------------------------------------------------------------- | -------- |
+| FT-1  | 면접 범주 버튼 즉시 렌더링      | 홈 화면 접속 → 입력창 하단 툴바 확인      | 로딩/스켈레톤 없이 "면접 범주" 버튼 즉시 표시                                | High     |
+| FT-2  | Popover 열기                    | 입력창 하단 "면접 범주" 버튼 클릭         | 2×2 카드 그리드 Popover 열림. 4개 범주 모두 표시                             | High     |
+| FT-3  | 면접 범주 선택                  | Popover에서 "CS 기초" 카드 클릭           | Popover 닫힘. 툴바 버튼 → "CS 기초" 파란 텍스트+Brain 아이콘으로 변경        | High     |
+| FT-4  | 선택된 범주 Pill 표시           | "CS 기초" 선택 후 입력창 내부 상단 확인   | 파란색 Pill (Brain 아이콘 + "CS 기초" + X 버튼) 표시                         | High     |
+| FT-5  | Pill X 버튼으로 범주 해제       | Pill의 X 버튼 클릭                        | Pill 사라짐. 툴바 버튼 기본 상태로 복원                                      | High     |
+| FT-6  | 같은 범주 재클릭 해제           | 선택된 범주 재클릭                        | 선택 해제. 기본 상태로 복원                                                  | Medium   |
+| FT-7  | 검색 시 면접 범주 코드 URL 전달 | "SYSTEM_DESIGN" 선택 후 검색              | URL에 `interview_type=SYSTEM_DESIGN` 포함 (UUID 없음)                        | High     |
+| FT-8  | 검색 페이지 배지 표시           | `/search?q=테스트&interview_type=CS` 접속 | `InterviewTypeBadge`에 "CS 기초" 파란색 배지 표시                            | High     |
+| FT-9  | 인터뷰 시작 시 코드→UUID 변환   | "PROJECT" 선택 후 인터뷰 시작             | POST `/api/sessions`에 `interview_type_code: "PROJECT"` 전송. DB에 UUID 저장 | High     |
+| FT-10 | 샘플 프롬프트 클릭 시 범주 유지 | 범주 선택 후 샘플 프롬프트 클릭           | URL에 `interview_type` 파라미터 유지                                         | Medium   |
+| FT-11 | 비로그인 상태 범주 선택         | 로그아웃 상태에서 범주 선택 후 검색       | 검색 페이지 정상 이동. 배지 표시. 인터뷰 시작 시 로그인 페이지로 이동        | Medium   |
+| FT-12 | 범주 순차 전환                  | CS → 프로젝트 기반 전환                   | 이전 선택 해제 후 새 선택으로 즉시 전환                                      | Medium   |
+
+### 엣지 케이스 테스트
+
+| #    | 시나리오                                                        | 예상 결과                                              | 우선순위 |
+| ---- | --------------------------------------------------------------- | ------------------------------------------------------ | -------- |
+| EC-1 | 잘못된 interview_type 코드 URL 접속 (`?interview_type=INVALID`) | 배지 미표시. 에러 없이 정상 렌더링                     | High     |
+| EC-2 | 면접 범주 미선택 세션 생성                                      | `interview_type_id = null`로 저장. 세션 생성 정상 완료 | High     |
+| EC-3 | DB에 없는 코드로 세션 생성 API 호출                             | `interview_type_id = null` 처리. 500 에러 없음         | High     |
+| EC-4 | 파일 첨부 + 면접 범주 동시 선택 후 검색                         | 두 파라미터 모두 URL에 포함                            | Medium   |
+| EC-5 | Popover 열린 상태에서 Escape 키                                 | Popover 닫힘. 선택 상태 변경 없음                      | Medium   |
+| EC-6 | Popover 외부 클릭                                               | Popover 닫힘. 선택 상태 변경 없음                      | Medium   |
+| EC-7 | 면접 범주 + 트렌드 토픽 동시 선택                               | 두 Pill이 나란히 표시. 각각 독립 해제 가능             | Medium   |
+| EC-8 | 파일 업로드 중 버튼 클릭                                        | `disabled` 상태. Popover 열리지 않음                   | Medium   |
+
+### UI/UX 테스트
+
+| #    | 확인 항목                             | 예상 결과                                                | 우선순위 |
+| ---- | ------------------------------------- | -------------------------------------------------------- | -------- |
+| UI-1 | 범주별 색상 (blue/green/purple/amber) | 버튼 텍스트, Pill, 카드 테두리 모두 해당 색상            | Medium   |
+| UI-2 | Popover 카드 선택 체크 표시           | 선택된 카드 우측 상단 체크 아이콘 (scale 0→1 애니메이션) | Medium   |
+| UI-3 | 반응형 Popover 너비                   | 모바일에서 `calc(100vw-2rem)`, 최대 480px                | Medium   |
+| UI-4 | 툴바 아이콘 전환                      | 미선택: LayoutGrid, 선택: 범주별 아이콘                  | Medium   |
+
+### 회귀 테스트
+
+| #    | 기능                               | 예상 결과                                             | 우선순위 |
+| ---- | ---------------------------------- | ----------------------------------------------------- | -------- |
+| RT-1 | 홈 화면 기본 검색 (범주 미선택)    | 정상 검색. `interview_type` 파라미터 없어도 에러 없음 | High     |
+| RT-2 | 아카이브 `InterviewTypeBadge`      | 기존과 동일하게 렌더링                                | High     |
+| RT-3 | 트렌드 토픽 선택 기능              | 기존과 동일하게 동작                                  | High     |
+| RT-4 | 레퍼런스 파일 첨부                 | 툴바 레이아웃 변경 없이 정상 동작                     | High     |
+| RT-5 | 검색 페이지 질문 재생성            | 면접 범주 코드가 재요청에 유지                        | High     |
+| RT-6 | GET `/api/sessions` 면접 범주 필터 | UUID 기반 필터 정상 동작 (GET API 변경 없음)          | Medium   |

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -227,7 +227,18 @@ export async function POST(request: NextRequest) {
 
     const body = await request.json();
     let { query, question_ids, questions: questionsData } = body;
-    const { interview_type_id } = body;
+    const { interview_type_code } = body;
+
+    // interview_type_code → interview_type_id (UUID) 조회
+    let interview_type_id: string | null = null;
+    if (interview_type_code) {
+      const { data: interviewType } = await supabaseAdmin
+        .from("interview_types")
+        .select("id")
+        .eq("code", interview_type_code)
+        .single();
+      interview_type_id = interviewType?.id ?? null;
+    }
 
     // 입력 검증 및 길이 제한
     query = query?.slice(0, 500)?.trim() || null; // 최대 500자

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,14 +27,17 @@ import {
   getCurrentUser,
   signOut,
   getLastSelectedTeamSpaceApi,
-  getInterviewTypesApi,
-  type ApiInterviewType,
 } from "@/lib/api";
 import { useAuth } from "@/hooks/useAuth";
 import { TeamSpaceSelector } from "@/components/TeamSpaceSelector";
 import { TeamSpaceIntro } from "@/components/TeamSpaceIntro";
 import { validateInterviewInput } from "@/lib/validation";
-import { InterviewTypeSelector } from "@/components/InterviewTypeSelector";
+import {
+  InterviewTypePopoverSelector,
+  SelectedInterviewTypePill,
+} from "@/components/InterviewTypeSelector";
+import { getInterviewTypeByCode } from "@/data/interview-types";
+import type { InterviewTypeCode } from "@/types/interview";
 import {
   TrendTopicSelector,
   SelectedTrendPill,
@@ -73,28 +76,10 @@ export default function Home() {
     "owner" | "member" | null
   >(null);
   const [inputWarning, setInputWarning] = useState<string | null>(null);
-  const [interviewTypes, setInterviewTypes] = useState<ApiInterviewType[]>([]);
-  const [selectedInterviewTypeId, setSelectedInterviewTypeId] = useState<
-    string | null
-  >(null);
-  const [isLoadingInterviewTypes, setIsLoadingInterviewTypes] = useState(true);
+  const [selectedInterviewTypeCode, setSelectedInterviewTypeCode] =
+    useState<InterviewTypeCode | null>(null);
   const [selectedTrendTopic, setSelectedTrendTopic] =
     useState<TrendTopic | null>(null);
-
-  // 면접 범주 로드
-  useEffect(() => {
-    const loadInterviewTypes = async () => {
-      try {
-        const response = await getInterviewTypesApi();
-        setInterviewTypes(response.interviewTypes);
-      } catch (error) {
-        console.error("면접 범주 로드 실패:", error);
-      } finally {
-        setIsLoadingInterviewTypes(false);
-      }
-    };
-    loadInterviewTypes();
-  }, []);
 
   useEffect(() => {
     // 로그인 상태 확인 후 마지막 선택한 팀스페이스 불러오기
@@ -423,14 +408,8 @@ export default function Home() {
       }
 
       // 면접 범주가 선택되어 있으면 전달
-      if (selectedInterviewTypeId) {
-        const selectedType = interviewTypes.find(
-          (t) => t.id === selectedInterviewTypeId,
-        );
-        if (selectedType) {
-          params.append("interview_type", selectedType.code);
-          params.append("interview_type_id", selectedInterviewTypeId);
-        }
+      if (selectedInterviewTypeCode) {
+        params.append("interview_type", selectedInterviewTypeCode);
       }
 
       // 트렌드 토픽이 선택되어 있으면 전달
@@ -466,14 +445,8 @@ export default function Home() {
 
     // 면접 범주가 선택되어 있으면 전달
     const params = new URLSearchParams({ q: sample });
-    if (selectedInterviewTypeId) {
-      const selectedType = interviewTypes.find(
-        (t) => t.id === selectedInterviewTypeId,
-      );
-      if (selectedType) {
-        params.append("interview_type", selectedType.code);
-        params.append("interview_type_id", selectedInterviewTypeId);
-      }
+    if (selectedInterviewTypeCode) {
+      params.append("interview_type", selectedInterviewTypeCode);
     }
 
     // 트렌드 토픽이 선택되어 있으면 전달
@@ -574,30 +547,6 @@ export default function Home() {
           transition={{ duration: 0.6, delay: 0.2, ease: "easeOut" }}
           className="w-full max-w-2xl"
         >
-          {/* Interview Type Selector - 채팅창 위에 배치 */}
-          <div className="mb-3 md:mb-4">
-            <p className="text-xs md:text-sm text-muted-foreground mb-2 text-center">
-              면접 범주 선택 (선택사항)
-            </p>
-            {isLoadingInterviewTypes ? (
-              <div className="flex flex-wrap justify-center gap-2">
-                {[1, 2, 3].map((i) => (
-                  <div
-                    key={i}
-                    className="h-10 w-24 rounded-full bg-muted/50 animate-pulse"
-                  />
-                ))}
-              </div>
-            ) : (
-              <InterviewTypeSelector
-                interviewTypes={interviewTypes}
-                selectedTypeId={selectedInterviewTypeId}
-                onSelect={setSelectedInterviewTypeId}
-                disabled={isUploading}
-              />
-            )}
-          </div>
-
           {/* Search Form */}
           <form onSubmit={handleSubmit}>
             <div
@@ -625,13 +574,27 @@ export default function Home() {
                   </div>
                 </div>
               )}
-              {/* 선택된 트렌드 토픽 Pill (검색창 상단) */}
-              {selectedTrendTopic && (
-                <div className="px-3 pt-2.5 md:px-5 md:pt-3">
-                  <SelectedTrendPill
-                    topic={selectedTrendTopic}
-                    onRemove={() => setSelectedTrendTopic(null)}
-                  />
+              {/* 선택된 면접 범주 / 트렌드 토픽 Pill (검색창 상단) */}
+              {(selectedInterviewTypeCode || selectedTrendTopic) && (
+                <div className="px-3 pt-2.5 md:px-5 md:pt-3 flex items-center gap-1.5 flex-wrap">
+                  {selectedInterviewTypeCode &&
+                    (() => {
+                      const type = getInterviewTypeByCode(
+                        selectedInterviewTypeCode,
+                      );
+                      return type ? (
+                        <SelectedInterviewTypePill
+                          type={type}
+                          onRemove={() => setSelectedInterviewTypeCode(null)}
+                        />
+                      ) : null;
+                    })()}
+                  {selectedTrendTopic && (
+                    <SelectedTrendPill
+                      topic={selectedTrendTopic}
+                      onRemove={() => setSelectedTrendTopic(null)}
+                    />
+                  )}
                 </div>
               )}
               <div className="flex items-center px-3 py-2.5 md:px-5 md:py-4 gap-2 md:gap-4">
@@ -753,8 +716,14 @@ export default function Home() {
                       className="hidden"
                     />
 
-                    {/* File count + Trend Topic */}
+                    {/* File count + 면접 범주 + Trend Topic */}
                     <div className="ml-auto flex items-center gap-3">
+                      <InterviewTypePopoverSelector
+                        selectedTypeCode={selectedInterviewTypeCode}
+                        onSelect={setSelectedInterviewTypeCode}
+                        disabled={isUploading}
+                      />
+                      <span className="text-border/60">|</span>
                       <TrendTopicSelector
                         selectedTopic={selectedTrendTopic}
                         onSelect={handleTrendTopicSelect}
@@ -768,7 +737,7 @@ export default function Home() {
                 </div>
               )}
 
-              {/* Reference Files Upload (when no files) + Trend Topic Selector */}
+              {/* Reference Files Upload (when no files) + 면접 범주 + Trend Topic Selector */}
               {referenceFiles.length === 0 && (
                 <div className="px-3 pb-2 md:px-5 md:pb-3 border-t border-border/30">
                   <div className="flex items-center gap-3 md:gap-4 pt-2 md:pt-3">
@@ -791,6 +760,12 @@ export default function Home() {
                       multiple
                       onChange={handleFileSelect}
                       className="hidden"
+                    />
+                    <span className="text-border/60">|</span>
+                    <InterviewTypePopoverSelector
+                      selectedTypeCode={selectedInterviewTypeCode}
+                      onSelect={setSelectedInterviewTypeCode}
+                      disabled={isUploading}
                     />
                     <span className="text-border/60">|</span>
                     <TrendTopicSelector

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -32,8 +32,11 @@ import {
   isLoggedIn,
   checkFavoriteApi,
   createSessionApi,
-  type ApiInterviewType,
 } from "@/lib/api";
+import {
+  getInterviewTypeByCode,
+  type StaticInterviewType,
+} from "@/data/interview-types";
 import { InterviewTypeBadge } from "@/components/InterviewTypeSelector";
 
 // API 응답 타입
@@ -53,7 +56,6 @@ function SearchContent() {
   const query = searchParams.get("q") || "";
   const referenceUrlsParam = searchParams.get("references") || "";
   const interviewTypeCode = searchParams.get("interview_type") || null;
-  const interviewTypeId = searchParams.get("interview_type_id") || null;
   const trendTopicParam = searchParams.get("trend_topic") || null;
   const isDemoMode =
     searchParams.get("demo") === "true" &&
@@ -77,47 +79,18 @@ function SearchContent() {
     category: string;
   } | null>(null);
   const [referenceNotice, setReferenceNotice] = useState<string | null>(null);
-  const [interviewType, setInterviewType] = useState<ApiInterviewType | null>(
-    null,
-  );
+  const [interviewType, setInterviewType] =
+    useState<StaticInterviewType | null>(null);
 
   // 검색이 이미 시작되었는지 추적하는 ref
   const hasStartedSearch = useRef(false);
 
-  // 면접 범주 정보 구성
+  // 면접 범주 정보 구성 (정적 데이터에서 조회)
   useEffect(() => {
-    if (interviewTypeCode && interviewTypeId) {
-      // URL 파라미터에서 면접 범주 정보 구성
-      const typeInfo: ApiInterviewType = {
-        id: interviewTypeId,
-        code: interviewTypeCode,
-        name: interviewTypeCode,
-        displayName:
-          interviewTypeCode === "CS"
-            ? "CS 기초"
-            : interviewTypeCode === "PROJECT"
-              ? "프로젝트 기반"
-              : interviewTypeCode === "SYSTEM_DESIGN"
-                ? "시스템 설계"
-                : interviewTypeCode,
-        description: null,
-        icon:
-          interviewTypeCode === "CS"
-            ? "Brain"
-            : interviewTypeCode === "PROJECT"
-              ? "FolderKanban"
-              : "Network",
-        color:
-          interviewTypeCode === "CS"
-            ? "blue"
-            : interviewTypeCode === "PROJECT"
-              ? "green"
-              : "purple",
-        sortOrder: 0,
-      };
-      setInterviewType(typeInfo);
+    if (interviewTypeCode) {
+      setInterviewType(getInterviewTypeByCode(interviewTypeCode) ?? null);
     }
-  }, [interviewTypeCode, interviewTypeId]);
+  }, [interviewTypeCode]);
 
   // 레퍼런스 URL 파싱 함수 (동기적으로 파싱)
   const parseReferenceUrls = useCallback((): Array<{
@@ -519,7 +492,7 @@ function SearchContent() {
     setIsStartingInterview(true);
 
     try {
-      // API를 통해 세션 생성 (면접 범주 ID 포함)
+      // API를 통해 세션 생성 (면접 범주 코드 포함)
       const sessionData = await createSessionApi(
         query,
         questions.map((q) => ({
@@ -527,7 +500,7 @@ function SearchContent() {
           hint: q.hint,
           category: q.category,
         })),
-        interviewTypeId,
+        interviewTypeCode,
       );
 
       router.push(`/interview?session=${sessionData.session.id}`);

--- a/src/components/InterviewTypeSelector.tsx
+++ b/src/components/InterviewTypeSelector.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { motion } from "framer-motion";
 import {
   Brain,
@@ -7,11 +8,21 @@ import {
   Network,
   BookOpen,
   Check,
-  Sparkles,
+  ChevronDown,
+  LayoutGrid,
+  X,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import type { ApiInterviewType } from "@/lib/api";
-import { useIsMobile } from "@/hooks/useMediaQuery";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import {
+  INTERVIEW_TYPES,
+  type StaticInterviewType,
+} from "@/data/interview-types";
+import type { InterviewTypeCode } from "@/types/interview";
 
 // 아이콘 매핑
 const ICON_MAP: Record<string, React.ComponentType<{ className?: string }>> = {
@@ -67,152 +78,187 @@ const COLOR_MAP: Record<
   },
 };
 
-interface InterviewTypeSelectorProps {
-  interviewTypes: ApiInterviewType[];
-  selectedTypeId: string | null;
-  onSelect: (typeId: string | null) => void;
+// ── 입력창 하단 툴바에 배치되는 면접 범주 선택 트리거 + Popover ──
+interface InterviewTypePopoverSelectorProps {
+  selectedTypeCode: InterviewTypeCode | null;
+  onSelect: (typeCode: InterviewTypeCode | null) => void;
   disabled?: boolean;
 }
 
-export function InterviewTypeSelector({
-  interviewTypes,
-  selectedTypeId,
+export function InterviewTypePopoverSelector({
+  selectedTypeCode,
   onSelect,
   disabled = false,
-}: InterviewTypeSelectorProps) {
-  const isMobile = useIsMobile();
+}: InterviewTypePopoverSelectorProps) {
+  const [open, setOpen] = useState(false);
 
-  const handleSelect = (typeId: string) => {
+  const selectedType = selectedTypeCode
+    ? INTERVIEW_TYPES.find((t) => t.code === selectedTypeCode)
+    : null;
+  const selectedColors = selectedType
+    ? (COLOR_MAP[selectedType.color] ?? COLOR_MAP.blue)
+    : null;
+  const SelectedIcon = selectedType
+    ? (ICON_MAP[selectedType.icon] ?? Brain)
+    : null;
+
+  const handleSelect = (code: InterviewTypeCode) => {
     if (disabled) return;
-    // 같은 타입 클릭 시 선택 해제
-    if (selectedTypeId === typeId) {
-      onSelect(null);
-    } else {
-      onSelect(typeId);
-    }
+    // 같은 범주 클릭 시 선택 해제
+    onSelect(selectedTypeCode === code ? null : code);
+    setOpen(false);
   };
 
-  // 모바일: 줄바꿈되는 칩 형태 (체크 아이콘 없이 배경/테두리로 선택 표시)
-  if (isMobile) {
-    return (
-      <div className="flex flex-wrap justify-center gap-2">
-        {interviewTypes.map((type) => {
-          const isSelected = selectedTypeId === type.id;
-          const IconComponent = ICON_MAP[type.icon || "Brain"] || Brain;
-          const colors = COLOR_MAP[type.color || "blue"] || COLOR_MAP.blue;
-
-          return (
-            <button
-              key={type.id}
-              type="button"
-              onClick={() => handleSelect(type.id)}
-              disabled={disabled}
-              className={cn(
-                "flex items-center gap-1.5 px-3 py-2 rounded-full border-2 transition-colors min-h-[40px]",
-                "focus:outline-none focus-visible:outline-none",
-                disabled && "opacity-50 cursor-not-allowed",
-                isSelected
-                  ? `${colors.selectedBg} ${colors.border} ${colors.text} shadow-sm`
-                  : "bg-card border-border/40 text-foreground hover:border-border hover:bg-muted/50",
-              )}
-            >
-              <IconComponent
-                className={cn(
-                  "w-4 h-4 flex-shrink-0",
-                  !isSelected && colors.text, // 미선택 시에도 아이콘에 색상
-                )}
-              />
-              <span className="text-sm font-medium">{type.displayName}</span>
-            </button>
-          );
-        })}
-      </div>
-    );
-  }
-
-  // 데스크톱: 기존 카드 레이아웃
   return (
-    <div className="grid grid-cols-3 gap-3">
-      {interviewTypes.map((type) => {
-        const isSelected = selectedTypeId === type.id;
-        const IconComponent = ICON_MAP[type.icon || "Brain"] || Brain;
-        const colors = COLOR_MAP[type.color || "blue"] || COLOR_MAP.blue;
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          disabled={disabled}
+          className={cn(
+            "flex items-center gap-1.5 text-xs md:text-sm transition-colors",
+            "focus:outline-none focus-visible:outline-none",
+            disabled && "opacity-50 cursor-not-allowed",
+            selectedType && selectedColors
+              ? selectedColors.text
+              : "text-muted-foreground hover:text-foreground cursor-pointer",
+          )}
+        >
+          {selectedType && SelectedIcon && selectedColors ? (
+            <SelectedIcon
+              className={cn("w-3.5 h-3.5 md:w-4 md:h-4", selectedColors.text)}
+            />
+          ) : (
+            <LayoutGrid className="w-3.5 h-3.5 md:w-4 md:h-4" />
+          )}
+          <span>{selectedType ? selectedType.displayName : "면접 범주"}</span>
+          <ChevronDown className="w-3 h-3 text-muted-foreground/60" />
+        </button>
+      </PopoverTrigger>
 
-        return (
-          <motion.button
-            key={type.id}
-            type="button"
-            onClick={() => handleSelect(type.id)}
-            disabled={disabled}
-            className={cn(
-              "relative flex flex-col items-start text-left p-4 rounded-xl border-2 transition-all duration-200",
-              "focus:outline-none focus-visible:outline-none",
-              disabled && "opacity-50 cursor-not-allowed",
-              isSelected
-                ? `${colors.selectedBg} ${colors.border} shadow-md`
-                : `bg-card border-border/50 ${colors.hoverBorder} hover:shadow-sm`,
-            )}
-          >
-            {/* 선택 표시 */}
-            {isSelected && (
-              <motion.div
-                initial={{ scale: 0 }}
-                animate={{ scale: 1 }}
-                className={cn(
-                  "absolute top-3 right-3 w-6 h-6 rounded-full flex items-center justify-center",
-                  colors.bg,
-                  colors.text,
-                )}
-              >
-                <Check className="w-3.5 h-3.5" strokeWidth={3} />
-              </motion.div>
-            )}
+      <PopoverContent
+        align="start"
+        className="w-[calc(100vw-2rem)] max-w-[480px] p-3"
+        sideOffset={8}
+      >
+        <div className="space-y-2.5">
+          <p className="text-xs text-muted-foreground">
+            선택한 범주에 맞게 AI 면접 질문이 특화됩니다
+          </p>
+          <div className="grid grid-cols-2 gap-2">
+            {INTERVIEW_TYPES.map((type) => {
+              const isSelected = selectedTypeCode === type.code;
+              const IconComponent = ICON_MAP[type.icon] ?? Brain;
+              const colors = COLOR_MAP[type.color] ?? COLOR_MAP.blue;
 
-            {/* 아이콘 */}
-            <div
-              className={cn(
-                "w-10 h-10 rounded-xl flex items-center justify-center mb-3",
-                colors.bg,
-              )}
-            >
-              <IconComponent className={cn("w-5 h-5", colors.text)} />
-            </div>
+              return (
+                <motion.button
+                  key={type.code}
+                  type="button"
+                  onClick={() => handleSelect(type.code)}
+                  whileTap={{ scale: 0.97 }}
+                  className={cn(
+                    "relative flex flex-col items-start text-left p-3 rounded-xl border-2 transition-all duration-150",
+                    "focus:outline-none focus-visible:outline-none",
+                    isSelected
+                      ? `${colors.selectedBg} ${colors.border}`
+                      : "bg-card border-border/40 hover:border-border/70 hover:bg-muted/30",
+                  )}
+                >
+                  {/* 선택 체크 */}
+                  {isSelected && (
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      className={cn(
+                        "absolute top-2.5 right-2.5 w-5 h-5 rounded-full flex items-center justify-center",
+                        colors.bg,
+                        colors.text,
+                      )}
+                    >
+                      <Check className="w-3 h-3" strokeWidth={3} />
+                    </motion.div>
+                  )}
 
-            {/* 제목 */}
-            <h3
-              className={cn(
-                "text-base font-semibold mb-1",
-                isSelected ? colors.text : "text-foreground",
-              )}
-            >
-              {type.displayName}
-            </h3>
+                  {/* 아이콘 */}
+                  <div
+                    className={cn(
+                      "w-8 h-8 rounded-lg flex items-center justify-center mb-2",
+                      colors.bg,
+                    )}
+                  >
+                    <IconComponent className={cn("w-4 h-4", colors.text)} />
+                  </div>
 
-            {/* 설명 - 전체 표시 */}
-            <p className="text-sm text-muted-foreground leading-relaxed mb-3">
-              {type.description}
-            </p>
+                  {/* 제목 */}
+                  <span
+                    className={cn(
+                      "text-sm font-semibold mb-1",
+                      isSelected ? colors.text : "text-foreground",
+                    )}
+                  >
+                    {type.displayName}
+                  </span>
 
-            {/* 선택 시 혜택 안내 */}
-            <div
-              className={cn(
-                "flex items-center gap-1.5 text-xs font-medium mt-auto pt-2 border-t border-border/30 w-full",
-                isSelected ? colors.text : "text-muted-foreground",
-              )}
-            >
-              <Sparkles className="w-3.5 h-3.5" />
-              <span>이 분야 맞춤 질문 생성</span>
-            </div>
-          </motion.button>
-        );
-      })}
-    </div>
+                  {/* 설명 */}
+                  <p className="text-xs text-muted-foreground leading-relaxed">
+                    {type.description}
+                  </p>
+                </motion.button>
+              );
+            })}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
   );
 }
 
-// 선택된 면접 범주를 배지로 표시하는 컴포넌트
+// ── 검색창 내부에 표시되는 선택된 면접 범주 Pill ──
+interface SelectedInterviewTypePillProps {
+  type: StaticInterviewType;
+  onRemove: () => void;
+}
+
+export function SelectedInterviewTypePill({
+  type,
+  onRemove,
+}: SelectedInterviewTypePillProps) {
+  const IconComponent = ICON_MAP[type.icon] ?? Brain;
+  const colors = COLOR_MAP[type.color] ?? COLOR_MAP.blue;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-center gap-1 pl-2 pr-1 py-0.5 rounded-full text-xs font-medium border",
+        colors.bgLight,
+        colors.border,
+        colors.text,
+      )}
+    >
+      <IconComponent className="w-3 h-3 flex-shrink-0" />
+      <span>{type.displayName}</span>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          onRemove();
+        }}
+        className={cn(
+          "ml-0.5 w-4 h-4 rounded-full flex items-center justify-center transition-colors",
+          "hover:bg-black/10",
+        )}
+        aria-label={`${type.displayName} 제거`}
+      >
+        <X className="w-2.5 h-2.5" />
+      </button>
+    </span>
+  );
+}
+
+// ── 선택된 면접 범주를 배지로 표시하는 컴포넌트 (아카이브 등에서 사용) ──
 interface InterviewTypeBadgeProps {
-  type: ApiInterviewType;
+  type: { displayName: string; icon: string | null; color: string | null };
   size?: "sm" | "md";
 }
 
@@ -220,8 +266,8 @@ export function InterviewTypeBadge({
   type,
   size = "sm",
 }: InterviewTypeBadgeProps) {
-  const IconComponent = ICON_MAP[type.icon || "Brain"] || Brain;
-  const colors = COLOR_MAP[type.color || "blue"] || COLOR_MAP.blue;
+  const IconComponent = ICON_MAP[type.icon ?? "Brain"] ?? Brain;
+  const colors = COLOR_MAP[type.color ?? "blue"] ?? COLOR_MAP.blue;
 
   return (
     <span

--- a/src/data/interview-types.ts
+++ b/src/data/interview-types.ts
@@ -1,0 +1,55 @@
+import type { InterviewTypeCode } from "@/types/interview";
+
+export interface StaticInterviewType {
+  code: InterviewTypeCode;
+  displayName: string;
+  description: string;
+  icon: string;
+  color: string;
+  sortOrder: number;
+}
+
+export const INTERVIEW_TYPES: StaticInterviewType[] = [
+  {
+    code: "CS",
+    displayName: "CS 기초",
+    description:
+      "운영체제, 네트워크, 알고리즘, 자료구조, 데이터베이스 등 컴퓨터 과학 핵심 개념을 심층적으로 다룹니다.",
+    icon: "Brain",
+    color: "blue",
+    sortOrder: 1,
+  },
+  {
+    code: "PROJECT",
+    displayName: "프로젝트 기반",
+    description:
+      "실제 프로젝트 경험, 기술 선택의 이유, 트러블슈팅 경험을 중심으로 실무 역량을 평가합니다.",
+    icon: "FolderKanban",
+    color: "green",
+    sortOrder: 2,
+  },
+  {
+    code: "SYSTEM_DESIGN",
+    displayName: "시스템 설계",
+    description:
+      "대용량 트래픽 처리, 분산 시스템, 데이터 모델링 등 아키텍처 설계 역량을 평가합니다.",
+    icon: "Network",
+    color: "purple",
+    sortOrder: 3,
+  },
+  {
+    code: "CASE_STUDY",
+    displayName: "케이스 스터디",
+    description:
+      "실제 기업 사례를 분석하고 기술적 의사결정 과정과 트레이드오프를 심층 토론합니다.",
+    icon: "BookOpen",
+    color: "amber",
+    sortOrder: 4,
+  },
+];
+
+export function getInterviewTypeByCode(
+  code: string,
+): StaticInterviewType | undefined {
+  return INTERVIEW_TYPES.find((t) => t.code === code);
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -365,7 +365,7 @@ export async function createSessionApi(
     category: string;
     questionId?: string;
   }>,
-  interviewTypeId?: string | null,
+  interviewTypeCode?: string | null,
 ): Promise<{ session: { id: string; created_at: string } }> {
   const questionIds = questions
     .map((q) => q.questionId)
@@ -381,7 +381,7 @@ export async function createSessionApi(
         hint: q.hint,
         category: q.category,
       })),
-      interview_type_id: interviewTypeId || undefined,
+      interview_type_code: interviewTypeCode || undefined,
     }),
   });
 }


### PR DESCRIPTION
## 요약

- 홈 화면 면접 범주 카드가 `useEffect` + `/api/interview-types` API 호출로 인해 hydration 이후에야 렌더링되던 문제 해결
- 면접 범주 데이터를 정적 상수(`src/data/interview-types.ts`)로 관리하여 API 라운드트립 완전 제거
- 면접 범주 선택 UI를 입력창 하단 툴바 Popover 방식으로 개선 (트렌드 토픽과 동일 패턴)

Closes #43

## 변경 사항

- `src/data/interview-types.ts` (신규): `StaticInterviewType` 인터페이스 및 `INTERVIEW_TYPES` 정적 상수 정의
- `src/components/InterviewTypeSelector.tsx`: Popover 트리거 + 2×2 카드 그리드 팝오버, 선택 시 컬러 Pill 컴포넌트로 완전 재작성
- `src/app/page.tsx`: `getInterviewTypesApi()` 호출 및 로딩 상태/스켈레톤 UI 제거, 정적 데이터 직접 사용
- `src/app/search/page.tsx`: `interviewTypeId` URL 파라미터 제거, `InterviewTypeCode` 기반으로 전환
- `src/lib/api.ts`: `createSessionApi` 파라미터 `interviewTypeId` → `interviewTypeCode`
- `src/app/api/sessions/route.ts`: `interview_type_code`를 받아 내부적으로 UUID 조회 후 저장

## 체크리스트

- [x] 요구사항 충족 확인
- [x] 불필요한 로그/디버그 코드 제거
- [x] 영향 범위 확인
- [x] 문서 업데이트 필요 여부 확인